### PR TITLE
use _fullInputPath as file name

### DIFF
--- a/plugin/compile-scss.js
+++ b/plugin/compile-scss.js
@@ -14,7 +14,7 @@ Plugin.registerSourceHandler("scss", function (compileStep) {
   }
 
   var options = {
-    file: compileStep.inputPath,
+    file: compileStep._fullInputPath,
     sourceComments: 'map',
     includePaths: [path.dirname(compileStep._fullInputPath)] // for @import
   };


### PR DESCRIPTION
compileStep.inputPath is correct relative to the root of the meteor project, which works fine for scss files in the meteor project. But, it doesn't work when a meteor[ite] package contains scss files because the relative root should be the package root. An easy way to fix this and make it work for both is to use the full file path (compileStep._fullInputPath). This is what i did in my forked branch.
