### PR TITLE
GH-19: Fix package name.

### DIFF
--- a/package.js
+++ b/package.js
@@ -13,6 +13,6 @@ Package._transitional_registerBuildPlugin({
 
 Package.on_test(function (api) {
   api.use(['test-helpers', 'tinytest']);
-  api.use(['spark']);
+  api.use(['ui']);
   api.add_files(['scss_tests.scss', 'scss_tests.js'], 'client');
 });


### PR DESCRIPTION
`spark` is now `ui`. However, this doesn't fix the tests. That seems to require a more arcane knowledge of Spark that I don't have.
