### PR TITLE
Import globbing (@import "*")

### DIFF
--- a/.npm/plugin/meteor-scss/npm-shrinkwrap.json
+++ b/.npm/plugin/meteor-scss/npm-shrinkwrap.json
@@ -1,5 +1,60 @@
 {
   "dependencies": {
+    "chalk": {
+      "version": "0.5.1",
+      "dependencies": {
+        "ansi-styles": {
+          "version": "1.1.0"
+        },
+        "escape-string-regexp": {
+          "version": "1.0.1"
+        },
+        "has-ansi": {
+          "version": "0.1.0",
+          "dependencies": {
+            "ansi-regex": {
+              "version": "0.2.1"
+            }
+          }
+        },
+        "strip-ansi": {
+          "version": "0.3.0",
+          "dependencies": {
+            "ansi-regex": {
+              "version": "0.2.1"
+            }
+          }
+        },
+        "supports-color": {
+          "version": "0.2.0"
+        }
+      }
+    },
+    "glob": {
+      "version": "4.0.5",
+      "dependencies": {
+        "inherits": {
+          "version": "2.0.1"
+        },
+        "minimatch": {
+          "version": "1.0.0",
+          "dependencies": {
+            "lru-cache": {
+              "version": "2.5.0"
+            },
+            "sigmund": {
+              "version": "1.0.0"
+            }
+          }
+        },
+        "once": {
+          "version": "1.3.0"
+        },
+        "graceful-fs": {
+          "version": "3.0.2"
+        }
+      }
+    },
     "lodash": {
       "version": "2.4.1"
     },
@@ -47,7 +102,7 @@
               "version": "1.0.7"
             },
             "debug": {
-              "version": "1.0.2",
+              "version": "1.0.4",
               "dependencies": {
                 "ms": {
                   "version": "0.6.2"

--- a/package.js
+++ b/package.js
@@ -6,11 +6,14 @@ Package._transitional_registerBuildPlugin({
   name: 'meteor-scss',
   use: [],
   sources: [
-    'plugin/compile-scss.js'
+    'plugin/compile-scss.js',
+    'plugin/import-globbing.js'
   ],
   npmDependencies: {
     'node-sass': '0.9.3',
-    'lodash': '2.4.1'
+    'lodash': '2.4.1',
+    'glob': '4.0.5',
+    'chalk': '0.5.1'
   }
 });
 

--- a/plugin/compile-scss.js
+++ b/plugin/compile-scss.js
@@ -39,7 +39,9 @@ var sourceHandler = function(compileStep) {
     sourceComments: 'none'
   });
 
-  options.file = compileStep._fullInputPath;
+  var sourcePath = compileStep._fullInputPath;
+  var sourceContents = globImports(sourcePath);
+  options.data = sourceContents;
 
   if (!_.isArray(options.includePaths)) {
     options.includePaths = [options.includePaths];

--- a/plugin/import-globbing.js
+++ b/plugin/import-globbing.js
@@ -1,0 +1,153 @@
+var fs = Npm.require('fs');
+var _ = Npm.require('lodash');
+var glob = Npm.require('glob');
+var chalk = Npm.require('chalk');
+
+
+initializeTarget = function (parsedImport) {
+  var fileExts = /\.(scssimport|scss|sass|css)/;
+  var target = {
+    line: parsedImport[0],
+    start: parsedImport[1],
+    path: parsedImport[2] || '',
+    file:  parsedImport[3] || '*', //import all from path if no filename
+    end: parsedImport[4],
+  }
+  target.quotemark = target.start.slice(-1); // ' or " 
+  target.leadingUnderscore = (target.file[0] === '_'); // boolean
+  target.fileExtension = fileExts.exec(target.file);
+  target.fileExtension = target.fileExtension && target.fileExtension[1];
+
+  return target;
+}
+
+
+//exclude certain import targets from globbing
+shouldBeGlobbed = function (target) {
+  var shouldGlob = true;
+  if (/http:\/\//.test(target.file)) {
+    shouldGlob = false;
+  }
+  else if (~(target.path + target.file).indexOf(target.quotemark)) {
+    // for now, not globbing more than one export file per line.
+    // e.g., @export "file a", "file path/*"; will fail
+    shouldGlob = false;
+  }
+  else if (target.fileExtension === 'css') {
+    shouldGlob = false;
+  }
+  return shouldGlob;
+}
+
+// Sass allows @imports to be specified without a leading
+// underscore or a file extension. Node-glob doesn't know
+// about these, so we have to search all the possibilities.
+// meteor-scss also allows the .scssimport extension
+var possiblePaths = function (target) {
+  var paths;
+  if (target.fileExtension === 'scssimport'){
+    // e.g., @import "style.scssimport"
+    paths = [target.path + target.file];
+  }
+  else if(target.fileExtension === 'scss' || target.fileExtension === 'sass') {
+    // e.g., @import "style.sass" 
+    // or    @import "_style.sass"
+    var importFile = target.file;
+    if (! target.leadingUnderscore)
+      importFile = '_' + target.file;
+    paths = [target.path + importFile];
+  }
+  else if(target.leadingUnderscore){
+    // e.g., @import "_style"
+    paths = [
+      target.path + target.file + '.scss',
+      target.path + target.file + '.sass'
+    ];
+  }
+  else {
+    // no filename cues, e.g., @import "style"
+    paths = [
+      target.path +'_' + target.file + '.scss',
+      target.path + '_' + target.file + '.sass',
+      target.path + target.file + '.scssimport'
+    ];
+  }
+  return paths;
+}
+
+
+expandGlobs = function (target) {
+  var globs = [];
+  _.each(possiblePaths(target), function (path) {
+    globs = globs.concat(glob.sync(path));
+  });
+  if (globs.length === 0){
+    // No results found. If the target contains the `*` character,
+    // silently drop the export but warn in the console.
+    // Otherwise, pass through so sass can return an error
+    // and mistyped names won't silently disappear.
+    // XXX Targeting only `*` is a bit arbitrary. Should we
+    // be targeting all glob characters?
+    var asteriskPresentInPath = ~(target.path + target.file).indexOf('*');
+    if (asteriskPresentInPath){
+      console && console.log(chalk.yellow('\nSCSS: no files found to import for:', 
+        target.path + target.file));
+    }
+    else {
+      // Restore original path
+      globs.push(target.path + target.file);
+    }
+  }
+  return globs;
+}
+
+
+// coordinate globbing for a single @import line
+performGlobbing = function (parsedImport) {
+  var target = initializeTarget(parsedImport);
+  if (shouldBeGlobbed(target)){
+    // insert globbed @import statements in place of original
+    var paths = expandGlobs(target);
+    var importStatements = _.map(paths, function (path) {
+      return  target.start + path + target.end;
+    })
+    return importStatements.join('\n');
+  }
+  else {
+    // pass @import statement as-is w/o globbing
+    return target.line;
+  }
+};
+
+
+/************************
+* Loads sass/scss file and expands any globbed @import paths.
+* Each @import statement with globbing is replaced by
+* multiple explicit @import statements.
+* The resulting file is then fed back to node-sass.
+*************************/
+globImports = function (sourcePath) {
+  var result = '';
+
+  var sourceContents = fs.readFileSync(sourcePath, 'utf8');
+  sourceContents = sourceContents || "\n"; // prevent empty string error
+
+  // importParser splits any import line into 4 parts. The 2nd and 3rd
+  // parts contains the path/filename for globbing (bounded by quotation marks)
+  // 1st and 4th parts contain the rest of the line to copy around globbed paths.
+  importParser = /(.*?@import\s['"])(.*\/)?(.*)(['"].*)/;
+  var lines = sourceContents.split('\n');
+  _.each(lines, function (line) {
+    var parsedImport = importParser.exec(line);
+    if (parsedImport) {
+      result = result + performGlobbing(parsedImport) + '\n';
+    }
+    else{
+      // line is not @import; just copy to output
+      result = result + line + '\n';
+    }
+
+  });
+  
+  return result;
+}


### PR DESCRIPTION
Having to specify exact paths to imported sass partials doesn't feel very meteoric:

    //...after importing variables used by the partials below
    
    // Views
    @import "../views/accounts/accounts";
    @import "../views/gameBoard/gameBoard";
    @import "../views/gameManagement/gameLists";

It's a hassle, and it's fragile - you have to update the master file every time you add or move a file; but you still need to do it that way if you want to be able to use app-wide variables and mix-ins. Wouldn't it be nicer if you could use globbing:

    // Views
    @import "../views/**/*"; //globstar `**` matches files in all subdirectories

Well, that's what I thought. With globbing, you could add partials to your heart's content and have them just show up the same way they would if you were using regular css with Meteor. I was going to ask what it would take to add it, but instead I ended up making this PR.

There is a [sass-globbing](https://github.com/chriseppstein/sass-globbing) Ruby module, but it doesn't appear to be implented in node-sass yet. Rather than wait for it, we can glob things ourselves. This involves scanning the files that do the importing and expanding their targets. The implementation basically looks at `@import "../views/**/*";` and makes an `@import` statement for each glob result as shown in the code at the top, inserting it at the same place in the file. It then passes the parsed file, rather than the filename, to node-sass for compilation. It will ignore urls, and although it will expand commented-out imports, they will remain commented out, and import targets (such as `@import "screen.scss" screen;`) are also preserved. [Nested @imports](http://sass-lang.com/documentation/file.SASS_REFERENCE.html#nested-import) should also have no problem. Globbing is performed by the [node glob module](https://github.com/isaacs/node-glob) and supports globstars like shown above, which will recursively match files down the directory tree. It also lets you leave off the underscore and the file extension in the `@import` statement as you normally can in scss.

@fourseven, have a look and see what you think. The implementation of this currently has globbing always on (although it shouldn't have any effect if you don't use globs). It's not highly tested, and it currently only works on scss files, not sass. If you are interested in this, I'd be up for making improvements and adding tests to the code. I don't really expect this to be very expensive from a performance perspective, but we are parsing files and there's a chance it might add up on a project with many large files (the number of partials is not relevant, though, as partials still aren't scanned). The code has a lot of comments, including a couple of XXX comments where things are a bit hacky/in need of further thought.

Some options: Globbing could be made optional (perhaps specify in scss.json or set up the globbing part as a separate smart package). If you like the separate package idea, I'd just need to be able to hook in and replace the filename with the parsed file. You can see there are very few changes to `compile-scss.js`.