### PR TITLE
Support options file in package-level root directory

### DIFF
--- a/plugin/compile-scss.js
+++ b/plugin/compile-scss.js
@@ -31,7 +31,8 @@ var sourceHandler = function(compileStep) {
     return;
   // XXX annoying that this is replicated in .css, .less, and .styl
 
-  var optionsFile = path.join(process.cwd(), 'scss.json');
+  var basePath = compileStep.fullInputPath.slice(0, -compileStep.inputPath.length);
+  var optionsFile = path.resolve(basePath, 'scss.json');
   var scssOptions = {};
   var sourceMap   = null;
 
@@ -69,6 +70,11 @@ var sourceHandler = function(compileStep) {
   if ( !_.isArray(options.includePaths) ) {
     options.includePaths = [options.includePaths];
   }
+
+  // Convert relative paths supplied via the options file to absolute paths.
+  options.includePaths = _.map(options.includePaths, function(includePath) {
+    return path.resolve(basePath, includePath);
+  });
 
   options.includePaths = options.includePaths.concat(path.dirname(compileStep.fullInputPath));
 

--- a/plugin/compile-scss.js
+++ b/plugin/compile-scss.js
@@ -62,7 +62,8 @@ var sourceHandler = function(compileStep) {
     // These are the magic incantations for sass sourcemaps
     sourceMapContents: true,
     sourceMapEmbed:    true,
-    outFile:           compileStep.pathForSourceMap
+    outFile:           compileStep.pathForSourceMap,
+    includePaths:      []
   }, scssOptions);
 
   options.file  = compileStep.fullInputPath;


### PR DESCRIPTION
Adds support for `scss.json` options file in package-level root directories. When compiling sass files inside packages, first check whether there is an options file at the package level root directory. If one exists, include it. Otherwise fall back to the one at `process.cwd()` (see the documentation for [path.resolve](http://nodejs.org/docs/v0.10.36/api/path.html#path_path_resolve_from_to) for more information).