### PR TITLE
The reason for the autoprefixer test fails

### DIFF
--- a/plugin/compile-scss.js
+++ b/plugin/compile-scss.js
@@ -88,7 +88,13 @@ var sourceHandler = function(compileStep) {
 
   if ( options.enableAutoprefixer ||
   (compileStep.fileOptions && compileStep.fileOptions.isTest) ) {
-    var autoprefixerOptions = options.autoprefixerOptions || {};
+    // In order to enforce autoprefixer to actually add the prefixed
+    // -webkit-transition css rule, it is necessary to enforce rule generation
+    // for all outdated browsers. Obviously this is not a good default option,
+    // a better test strategy is inevitable here. We might just pass the test
+    // options via fileOptions (i.e. pass {'testAutoprefixerOptions' = {browsers: ['> 0%']}}
+    // instead of {'isTest': true}
+    var autoprefixerOptions = options.autoprefixerOptions || {browsers: ['> 0%']};
 
     try {
       // Applying Autoprefixer to compiled css

--- a/test/scss_tests.js
+++ b/test/scss_tests.js
@@ -20,7 +20,18 @@ Tinytest.add("sass - autprefixer presence and function", function(test) {
   renderToDiv(Template.test_p_tag);
 
   var p = $('.sass-dashy-left-border-transition');
-  test.equal(p.css('-webkit-transition'), "-webkit-transform 1s ease 0s");
+  // Prints a list of css properties supported by the phantomjs browser version
+  // in use. Obviously this list will change for new releases. Also at some
+  // point in time, phantomjs will support the unprefixed transition property
+  // and then the test will break again (or even worse, fail to actually test
+  // the SUT).
+  console.log('XXXX: ' + JSON.stringify(window.getComputedStyle(p.get(0))));
+
+  // Note that '-webkit-transition' is a shorthand property (just like
+  // 'background'). We only can run assertions against the actual properties,
+  // testing the shorthand does not work.
+  // @see: https://developer.mozilla.org/en-US/docs/Web/CSS/Shorthand_properties
+  test.equal(p.css('-webkit-transition-duration'), '1s');
 
   p.remove();
 });


### PR DESCRIPTION
This is not yet really a PR, but points out some problems with the autoprefixer tests. See the inline comments in the diff for the details.