### PR TITLE
Add in a meteorImporter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@
 
 meteor/
 .build*
+
+*.tgz

--- a/plugin/compile-scss.js
+++ b/plugin/compile-scss.js
@@ -25,6 +25,7 @@ var loadJSONFile = function (filePath) {
   }
 };
 
+
 var sourceHandler = function(compileStep) {
   // Don't process partials
   if ( path.basename(compileStep.inputPath)[0] === '_' )
@@ -35,7 +36,6 @@ var sourceHandler = function(compileStep) {
   var optionsFile = path.resolve(basePath, 'scss.json');
   var scssOptions = {};
   var sourceMap   = null;
-
   if (fs.existsSync(optionsFile)) {
     scssOptions = loadJSONFile(optionsFile);
   }
@@ -57,13 +57,27 @@ var sourceHandler = function(compileStep) {
     }
   }
 
+  var packageRegexp = /(\w+\:(\w+))\/(.+)/i;
+  var basePackagePath = null;
+  var meteorImporter = function(url, prev, done) {
+    var resolvedPath = packageRegexp.exec(url);
+    // If file has a package prefix
+    if (resolvedPath) {
+      basePackagePath = path.resolve(basePath, ".meteor/local/build/programs/server/assets/packages", resolvedPath[1].replace(/\:/, "_"), resolvedPath[2]);
+      return {file: path.resolve(basePackagePath, resolvedPath[3])};
+    } else {
+      return {file: path.resolve((basePackagePath || basePath), url)};
+    }
+  }
+
   var options = _.extend({
     sourceMap:         true,
     // These are the magic incantations for sass sourcemaps
     sourceMapContents: true,
     sourceMapEmbed:    true,
     outFile:           compileStep.pathForSourceMap,
-    includePaths:      []
+    includePaths:      [],
+    importer:          meteorImporter
   }, scssOptions);
 
   options.file  = compileStep.fullInputPath;


### PR DESCRIPTION
Add the ability to resolve meteor packages from @import statements using the fact that they have a colon in the location string. For example bourbon could be imported as: `@import "wolves:bourbon/bourbon”;`

This then sets node-sass to resolve from
`.meteor/local/build/programs/server/assets/packages/wolves_bourbon/bourbon/bourbon`

Still a little brittle, but removes the need for importPaths set in the scss.json file