### PR TITLE
Provide a way to pass any option during testing

### DIFF
--- a/package.js
+++ b/package.js
@@ -25,5 +25,15 @@ Package.on_test(function (api) {
            'templating']);
   api.use(['fourseven:scss']);
   api.add_files(['test/scss_tests.html', 'test/scss_tests.js'], 'client');
-  api.add_files(['test/scss_tests.scss'], 'client',  {isTest:true});
+  api.add_files(['test/scss_tests.scss'], 'client',  {
+    testOptions: {
+      enableAutoprefixer: true,
+      autoprefixerOptions: {
+        // In order to force autoprefixer to actually add the prefixed
+        // -webkit-transition css rule, it is necessary to enforce rule
+        // generation for all outdated browsers.
+        browsers: ['> 0%']
+      }
+    }
+  });
 });

--- a/plugin/compile-scss.js
+++ b/plugin/compile-scss.js
@@ -38,6 +38,8 @@ var sourceHandler = function(compileStep) {
 
   if (fs.existsSync(optionsFile)) {
     scssOptions = loadJSONFile(optionsFile);
+  } else if (compileStep.fileOptions && compileStep.fileOptions.testOptions) {
+    scssOptions = compileStep.fileOptions.testOptions;
   }
 
   if ( scssOptions.useIndex ) {
@@ -93,15 +95,8 @@ var sourceHandler = function(compileStep) {
     });
   }
 
-  if ( options.enableAutoprefixer ||
-  (compileStep.fileOptions && compileStep.fileOptions.isTest) ) {
-    // In order to enforce autoprefixer to actually add the prefixed
-    // -webkit-transition css rule, it is necessary to enforce rule generation
-    // for all outdated browsers. Obviously this is not a good default option,
-    // a better test strategy is inevitable here. We might just pass the test
-    // options via fileOptions (i.e. pass {'testAutoprefixerOptions' = {browsers: ['> 0%']}}
-    // instead of {'isTest': true}
-    var autoprefixerOptions = options.autoprefixerOptions || {browsers: ['> 0%']};
+  if ( options.enableAutoprefixer) {
+    var autoprefixerOptions = options.autoprefixerOptions || {}
 
     try {
       // Applying Autoprefixer to compiled css


### PR DESCRIPTION
Follow-up to #69, provide a sensible way to pass any option via file options during tests.