### PR TITLE
changes accessSync to statSync to be compatible with Meteor 1.4

### DIFF
--- a/plugin/compile-scss.js
+++ b/plugin/compile-scss.js
@@ -82,9 +82,9 @@ class SassCompiler extends MultiFileCachingCompiler {
     //Handle deprecation of fs.existsSYnc
     //XXX: remove when meteor is fully on node 4+
     function fileExists(file){
-      if(fs.accessSync){
+      if(fs.statSync){
         try{
-          fs.accessSync(file,fs.R_OK);
+          fs.statSync(file);
         }catch(e){
           return false;
         }


### PR DESCRIPTION
The `Plugin.fs` object supplies `stat` and `statSync` in Meteor 1.4 instead of the expected `access` and `accessSync` functions currently in the code.

This PR fixes the issue and enables this package to work with Meteor 1.4.