### PR TITLE
supress sourceMapUrl in output file as it is sent as a header.

### DIFF
--- a/plugin/compile-scss.js
+++ b/plugin/compile-scss.js
@@ -194,6 +194,7 @@ class SassCompiler extends MultiFileCachingCompiler {
       sourceMapContents: true,
       sourceMapEmbed:    false,
       sourceComments:    false,
+      omitSourceMapUrl:  true,
       sourceMapRoot: '.',
       indentedSyntax : inputFile.getExtension() === 'sass',
       outFile: '.'+inputFile.getBasename(),


### PR DESCRIPTION
Fix for [Sourcemap error with root files 3.10](https://github.com/fourseven/meteor-scss/issues/232)