### PR TITLE
Ability to pass custom javascript functions to node-sass.

### DIFF
--- a/package.js
+++ b/package.js
@@ -1,18 +1,18 @@
 Package.describe({
   summary: 'Style with attitude. Sass and SCSS support for Meteor.js.',
-  version: "3.10.0",
+  version: "3.11.0",
   git: "https://github.com/fourseven/meteor-scss.git",
   name: "fourseven:scss"
 });
 
 Package.registerBuildPlugin({
   name: "compileScssBatch",
-  use: ['caching-compiler@1.1.7', 'ecmascript@0.5.8', 'underscore@1.0.9'],
+  use: ['caching-compiler@1.1.7', 'ecmascript@0.5.8', 'underscore@1.0.10'],
   sources: [
-    'plugin/compile-scss.js'
+    'plugin/compile-scss.js',
   ],
   npmDependencies: {
-    'node-sass': '3.10.0'
+    'node-sass': '4.3.0',
   }
 });
 


### PR DESCRIPTION
This is my first try at allowing [custom javascript functions as allowed by node-sass](https://www.npmjs.com/package/node-sass#functions--v300---experimental) to be used when compiling scss.

It has some problems I'd like your input and perhaps solving, but first let me explain how it currently works.

Extensions `scss.js` or `sass.js` are added to the list the plugin handles, and they're evaluated just like all other top level scss files. Any js files that have an underscore aren't used.

I initially tried to allow the custom importer to handle these files, and they could be imported just like other files, with a `{author:package}/file` syntax. You can still see the remnants of that attempt in a few commented out blocks.
It basically worked, but since the custom functions are all passed in the options object when node-sass is called, the custom js functions would be delayed behind the scss files, with the previously compiled version being used instead of the newest version. If you could dynamically change the functions object node-sass was using, then it would work fine. I tried that a couple of different ways, but I think node-sass is making a copy of the options object or something rather than using a reference to the object you passed, so that didn't work.

Also, right now it's using `eval` to get the functions object, which is the only way I could think of to get them since you can only `getContentsAsString()` for the file, rather than importing it or something like that. Any improvements you can think of there are much appreciated, because frankly that's gross and dangerous.

I've tested this with js files structured in this way:

```js
const sass = Npm.require('node-sass');

var customFunctions = {
	'headings($from: 1, $to: 6)': function(from, to) {
                // ...
		return list;
	}
}
customFunctions
```

`eval` returns the last output of the function, so placing `customFunctions` as the last thing works. Again, this is gross.

For building more complex frameworks or other cool sass functions this is a very handy thing to have. I've been working on a complex framework and that's why I wanted to get this working.

I'm happy to do the work of implementing any improvements you can think of, and also perfectly willing to make any documentation changes if you decide to adopt this.

Let me know what you think!
Blaine