### PR TITLE
Output formatted error messages including the line number of errors

### DIFF
--- a/plugin/compile-scss.js
+++ b/plugin/compile-scss.js
@@ -221,7 +221,7 @@ class SassCompiler extends MultiFileCachingCompiler {
       output = f.wait();
     } catch (e) {
       inputFile.error({
-        message: `Scss compiler error: ${e.message}\n`,
+        message: `Scss compiler error: ${e.formatted}\n`,
         sourcePath: inputFile.getDisplayPath()
       });
       return null;


### PR DESCRIPTION
When errors occur in CSS, the errors reported don't currently include details of where the error is.
For example with the following CSS imported via an `@import`.
```
.test {
  line-spacing: ;
}
```
The error is just `/client/main.scss: Scss compiler error: style declaration must contain a value`
With no other information about exactly where the error is.

This change uses the 'formatted' value of the error which includes the relevant details, for example:
```
   /client/main.scss: Scss compiler error: Error: style declaration must contain a value
   on line 4820 of ../node_modules/vuetify/dist/vuetify.min
   >>   line-height: ;
   --------------^
```