### PR TITLE
Add a way to read envvars from SCSS through env() SCSS function

### DIFF
--- a/package.js
+++ b/package.js
@@ -47,7 +47,10 @@ Package.onTest(function (api) {
     'test/include-paths/include-paths.scss',
     'test/include-paths/modules/module/_module.scss',
   ]);
-  
-  api.addFiles('tests.js', 'client');
 
+  // Tests for env()
+  process.env.FOURSEVEN_SCSS_WIDTH = '1px';
+  api.addFiles(['test/env.scss']);
+
+  api.addFiles('tests.js', 'client');
 });

--- a/plugin/compile-scss.js
+++ b/plugin/compile-scss.js
@@ -195,6 +195,9 @@ class SassCompiler extends MultiFileCachingCompiler {
       outFile: `.${inputFile.getBasename()}`,
       importer: importer,
       includePaths:      [],
+      functions: {
+        'env($key)': key => new sass.types.String(process.env[key.getValue()]),
+      },
     };
 
     options.file = this.getAbsoluteImportPath(inputFile);

--- a/test/env.scss
+++ b/test/env.scss
@@ -1,0 +1,3 @@
+.from-env {
+  width: env("FOURSEVEN_SCSS_WIDTH");
+}

--- a/tests.js
+++ b/tests.js
@@ -53,3 +53,15 @@ Tinytest.add('sass/scss - import from includePaths', function (test) {
   }
 
 });
+
+Tinytest.add('sass/scss - read environment variables with env()', function (test) {
+  var div = document.createElement('div');
+  document.body.appendChild(div);
+
+  try {
+    div.className = 'from-env';
+    test.equal(getStyleProperty(div, 'width'), '1px', div.className);
+  } finally {
+    document.body.removeChild(div);
+  }
+});


### PR DESCRIPTION
Following feature request https://github.com/fourseven/meteor-scss/issues/278

Add a way to read environment variables from SCSS (ie. a CDN url or a build number).

Ex in SCSS :

```
@function asset($path) {
  @return url(env("APP_ASSETS_DOMAIN") + $path + "?_g_build_=" + env("APP_BUILD_NUMBER"));
}
```