### PR TITLE
feat: meteor@3 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: node_js
 sudo: required
 node_js:
-  - "12"
-  - "14"
+  - "22"
 before_install:
   - "curl -L http://git.io/ejPSng | /bin/sh"

--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ Package.onUse(function (api) {
 ```
 
 ## Compatibility
+
 <table>
 <thead>
 <tr><th>Meteor Version</th><th>Recommended fourseven:scss version</th></tr>
@@ -36,6 +37,7 @@ Package.onUse(function (api) {
 <tr><td>1.4.0</td><td>3.8.1</td></tr>
 <tr><td>1.4.1+</td><td>4.5.4</td></tr>
 <tr><td>1.6+</td><td>4.12.0</td></tr>
+<tr><td>3.0+</td><td>4.17.0</td></tr>
 </tbody>
 </table>
 
@@ -132,7 +134,6 @@ possibility to resolve import paths:
 }
 ```
 
-
 ### Sourcemaps
 These are on by default.
 
@@ -149,6 +150,15 @@ In a Meteor 1.3+ project, do the same by running:
 meteor remove standard-minifier-css
 meteor add seba:minifiers-autoprefixer
 ```
+
+In a Meteor 3+ project prefixes supported via postcss:
+```
+meteor remove seba:minifiers-autoprefixer
+meteor add standard-minifier-css
+meteor npm install -D postcss postcss-load-config autoprefixer
+```
+
+Learn more about [`standard-minifier-css` setup in `meteor@^3` in its docs](https://docs.meteor.com/packages/standard-minifier-css.html)
 
 ## LibSass vs Ruby Sass
 Please note that this project uses [LibSass](https://github.com/hcatlin/libsass). LibSass is a C++ implementation of the Ruby Sass compiler. It has most of the features of the Ruby version, but not all of them. Things are improving, so please be patient. Before you ask, I have no intention of making a version of this package that links to the Ruby version instead.

--- a/package.js
+++ b/package.js
@@ -16,12 +16,12 @@ Package.registerBuildPlugin({
 });
 
 Package.onUse(function(api) {
-  api.versionsFrom(['3.0.1']);
+  api.versionsFrom(['2.8.0', '3.0.1']);
   api.use('isobuild:compiler-plugin@1.0.0');
 });
 
 Package.onTest(function(api) {
-  api.versionsFrom(['3.0.1']);
+  api.versionsFrom(['2.8.0', '3.0.1']);
   api.use(['test-helpers', 'tinytest']);
 
   api.use(['fourseven:scss']);

--- a/package.js
+++ b/package.js
@@ -1,30 +1,27 @@
 Package.describe({
   summary: 'Style with attitude. Sass and SCSS support for Meteor.js.',
-  version: '4.17.0-rc.0',
+  version: '4.17.0',
   git: 'https://github.com/Meteor-Community-Packages/meteor-scss.git',
   name: 'fourseven:scss',
 });
 
 Package.registerBuildPlugin({
   name: 'compileScssBatch',
-  use: [
-    'caching-compiler@2.0.0',
-    'ecmascript@0.16.9'
-  ],
+  use: ['caching-compiler@2.0.1', 'ecmascript@0.16.10'],
   sources: ['plugin/compile-scss.js'],
   npmDependencies: {
-    "node-sass": '9.0.0',
-    "@babel/runtime": "7.24.5"
+    'node-sass': '9.0.0',
+    '@babel/runtime': '7.26.0',
   }
-})
+});
 
 Package.onUse(function(api) {
-  api.versionsFrom(['2.8.0', '3.0.1']);
+  api.versionsFrom(['3.0.1']);
   api.use('isobuild:compiler-plugin@1.0.0');
 });
 
 Package.onTest(function(api) {
-  api.versionsFrom(['2.8.0', '3.0.1']);
+  api.versionsFrom(['3.0.1']);
   api.use(['test-helpers', 'tinytest']);
 
   api.use(['fourseven:scss']);


### PR DESCRIPTION
- Update travis.node_js to 22
- Update package dependencies
- Update docs with instructions
- Tested on Meteor@3.1.2 app

This PR has minor changes that makes it compatible with modern meteor@3 setup
@jankapunkt @StorytellerCZ please review

Tested with `postcss.config.js` file:
```js
module.exports = {
  plugins: {
    autoprefixer: {
      overrideBrowserslist: [
        'last 2 versions',
        '> 5%',
        'Firefox ESR',
        'IE 11'
      ]
    },
  }
};
```